### PR TITLE
BLD: how to run tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.log
 build/
 node_modules/
+.env
+enigma-js/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The contents of this repo are used in the [docker-environment](https://github.co
 
 This setup is only relevant for developers interested in manually debugging some of these tests, or wanting to tweak any particular test to adapt them to other applications:
 
-1.  Clone this repo:
+1.  Clone this repo and change folders:
 
     ```bash
     git clone git@github.com:enigmampc/integration-tests.git integration-tests/integration-tests
@@ -24,7 +24,7 @@ This setup is only relevant for developers interested in manually debugging some
     ENIGMA_ENV=COMPOSE
     ```
 
-3.  Download and save this file inside the folder you created in the previous step: [enigma-js.node.js](https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js)
+3.  Download and save the following file: [enigma-js.node.js](https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js) inside `enigma-js/lib`:
 
     ```bash
     wget -P enigma-js/lib https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # integration-tests
-Integration test suite for the Discovery release of the Enigma Protocol
+Integration test suite for the Discovery release of the Enigma Protocol.
+
+The contents of this repo are used in the [docker-environment](https://github.com/enigmampc/docker-environment) to create a `client` Docker image used to run these test automatically in our Continuous Integration (CI) environments.
+
+## Running tests locally
+
+This setup is only relevant for developers interested in manually debugging some of these tests, or wanting to tweak any particular test to adapt them to other applications: 
+
+1. Add an `.env` file with the following (and choose either `SW` or `HW` for `SGX_MODE)`
+
+    ```
+    SGX_MODE=SW
+    ENIGMA_ENV=COMPOSE
+    ```
+
+2. Create the following folder:
+
+    ```
+    mkdir enigma-js/lib
+    ```
+
+3. Download and save this file inside the folder you created in the previous step: [enigma-js.node.js](https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js)
+
+2. Clone [docker-environment](https://github.com/enigmampc/docker-environment) elsewhere in your computer, configure it, and start it.
+
+3. Once the network is fully up and running, run the following script once:
+
+    ```
+    ./local_init.bash
+    ```
+
+4. Then you can run the integration tests:
+
+    ```
+    test/runTests.bash
+    ```
+
+    or any one individual test:
+
+    ```
+    yarn test test/02_deploy_calculator.spec.js 
+    ```
+
+    please note that if you want to manually run them from inside the `test/` folder directly, you will have to copy the `.env` file there, or export these variable to the environment, for example:
+
+    ```
+    cd test
+    SGX_MODE=SW ENIGMA_ENV=COMPOSE yarn test 02_deploy_calculator.spec.js
+    ```

--- a/README.md
+++ b/README.md
@@ -1,50 +1,49 @@
 # integration-tests
+
 Integration test suite for the Discovery release of the Enigma Protocol.
 
 The contents of this repo are used in the [docker-environment](https://github.com/enigmampc/docker-environment) to create a `client` Docker image used to run these test automatically in our Continuous Integration (CI) environments.
 
 ## Running tests locally
 
-This setup is only relevant for developers interested in manually debugging some of these tests, or wanting to tweak any particular test to adapt them to other applications: 
+This setup is only relevant for developers interested in manually debugging some of these tests, or wanting to tweak any particular test to adapt them to other applications:
 
 1. Add an `.env` file with the following (and choose either `SW` or `HW` for `SGX_MODE)`
 
-    ```
-    SGX_MODE=SW
-    ENIGMA_ENV=COMPOSE
-    ```
+   ```
+   SGX_MODE=SW
+   ENIGMA_ENV=COMPOSE
+   ```
 
-2. Create the following folder:
+2. Download and save this file inside the folder you created in the previous step: [enigma-js.node.js](https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js)
 
-    ```
-    mkdir enigma-js/lib
-    ```
+   ```bash
+   wget -P enigma-js/lib https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js
+   ```
 
-3. Download and save this file inside the folder you created in the previous step: [enigma-js.node.js](https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js)
+3. Clone [docker-environment](https://github.com/enigmampc/docker-environment) elsewhere in your computer, configure it, and start it with `docker-compose up`.
 
-2. Clone [docker-environment](https://github.com/enigmampc/docker-environment) elsewhere in your computer, configure it, and start it.
+4. Once the network is fully up and running, run the following script once:
 
-3. Once the network is fully up and running, run the following script once:
+   ```bash
+   ./local_init.bash
+   ```
 
-    ```
-    ./local_init.bash
-    ```
+5. Then you can run the integration tests:
 
-4. Then you can run the integration tests:
+   ```
+   test/runTests.bash
+   ```
 
-    ```
-    test/runTests.bash
-    ```
+   or any one individual test:
 
-    or any one individual test:
+   ```
+   yarn test test/02_deploy_calculator.spec.js
+   ```
 
-    ```
-    yarn test test/02_deploy_calculator.spec.js 
-    ```
+   Please note that if you want to manually run them from inside the `test/` folder directly, you will have to copy the `.env` file there, or export these variable to the environment, for example:
 
-    please note that if you want to manually run them from inside the `test/` folder directly, you will have to copy the `.env` file there, or export these variable to the environment, for example:
-
-    ```
-    cd test
-    SGX_MODE=SW ENIGMA_ENV=COMPOSE yarn test 02_deploy_calculator.spec.js
-    ```
+   ```
+   cd test
+   SGX_MODE=SW ENIGMA_ENV=COMPOSE yarn test 02_deploy_calculator.spec.js
+   ```

--- a/README.md
+++ b/README.md
@@ -8,42 +8,51 @@ The contents of this repo are used in the [docker-environment](https://github.co
 
 This setup is only relevant for developers interested in manually debugging some of these tests, or wanting to tweak any particular test to adapt them to other applications:
 
-1. Add an `.env` file with the following (and choose either `SW` or `HW` for `SGX_MODE)`
+1.  Clone this repo:
 
-   ```
-   SGX_MODE=SW
-   ENIGMA_ENV=COMPOSE
-   ```
+    ```bash
+    git clone git@github.com:enigmampc/integration-tests.git integration-tests/integration-tests
+    cd integration-tests/integration-tests
+    ```
 
-2. Download and save this file inside the folder you created in the previous step: [enigma-js.node.js](https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js)
+    Note: Inside `integration-tests/integration-tests/` so when `local_init.bash` will create the `../build/` directory it won't pollute the parent directory of `integration-tests/` which is probably `$HOME/projects`.
 
-   ```bash
-   wget -P enigma-js/lib https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js
-   ```
+2.  Add an `.env` file with the following (and choose either `SW` or `HW` for `SGX_MODE)`
 
-3. Clone [docker-environment](https://github.com/enigmampc/docker-environment) elsewhere in your computer, configure it, and start it with `docker-compose up`.
+    ```
+    SGX_MODE=SW
+    ENIGMA_ENV=COMPOSE
+    ```
 
-4. Once the network is fully up and running, run the following script once:
+3.  Download and save this file inside the folder you created in the previous step: [enigma-js.node.js](https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js)
 
-   ```bash
-   ./local_init.bash
-   ```
+    ```bash
+    wget -P enigma-js/lib https://raw.githubusercontent.com/enigmampc/enigma-contract/develop/enigma-js/lib/enigma-js.node.js
+    ```
 
-5. Then you can run the integration tests:
+4.  Clone [docker-environment](https://github.com/enigmampc/docker-environment) elsewhere in your computer, configure it, and start it with `docker-compose up`.
 
-   ```
-   test/runTests.bash
-   ```
+5.  Once the network is fully up and running, run the following script once:
 
-   or any one individual test:
+    ```bash
+    ./local_init.bash
+    ```
 
-   ```
-   yarn test test/02_deploy_calculator.spec.js
-   ```
+6.  Then you can run the integration tests:
 
-   Please note that if you want to manually run them from inside the `test/` folder directly, you will have to copy the `.env` file there, or export these variable to the environment, for example:
+    ```
+    test/runTests.bash
+    ```
 
-   ```
-   cd test
-   SGX_MODE=SW ENIGMA_ENV=COMPOSE yarn test 02_deploy_calculator.spec.js
-   ```
+    or any one individual test:
+
+    ```
+    yarn test test/02_deploy_calculator.spec.js
+    ```
+
+    Please note that if you want to manually run them from inside the `test/` folder directly, you will have to copy the `.env` file there, or export these variable to the environment, for example:
+
+    ```
+    cd test
+    SGX_MODE=SW ENIGMA_ENV=COMPOSE yarn test 02_deploy_calculator.spec.js
+    ```

--- a/local_init.bash
+++ b/local_init.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+CONTAINER_ID=$(docker container ls | grep enigmampc/client | cut -d' ' -f1)
+mkdir -p ~/.enigma
+mkdir -p ../build
+docker cp $CONTAINER_ID:/root/build/contracts ../build
+sed -e 's_http://contract_http://localhost_g;s_http://bootstrap_http://localhost_g' ../build/contracts/addresses.json > ../build/contracts/addresses.new
+mv ../build/contracts/addresses.new ../build/contracts/addresses.json


### PR DESCRIPTION
This PR documents how to run the integration tests from the folder cloned in the host instead from inside the `client` container.